### PR TITLE
Remove deprecated mkPackageOptionMD

### DIFF
--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -16,7 +16,7 @@ in
   options.services.numtide-rke2 = {
     enable = mkEnableOption (lib.mdDoc "rke2");
 
-    package = lib.mkPackageOptionMD pkgs "rke2" { };
+    package = lib.mkPackageOption pkgs "rke2" { };
 
     role = mkOption {
       description = lib.mdDoc ''


### PR DESCRIPTION
Deprecated since 24.11
See https://nixos.org/manual/nixos/stable/release-notes.html#sec-release-24.11-lib-deprecations
